### PR TITLE
Add moment.calendar capability to localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ The number or date to localize.
 The translation key for providing the format string. Only needed for localizing dates.
 For the full list of formatting tokens which can be used in the format string, see http://momentjs.com/docs/#/displaying/format/.
 
+#### `calendarFormat` (string)
+The translation key for providing calendar formatting for dates.
+For the full list of details see http://momentjs.com/docs/#/displaying/calendar-time/.
+
 #### `options` (object)
 
 When localizing dates, a `strictParse` option can be provided. When set to `true`, `moment`'s strict parsing will be used.

--- a/__tests__/lib/I18n.specs.js
+++ b/__tests__/lib/I18n.specs.js
@@ -11,6 +11,9 @@ describe('I18n.js', () => {
         },
         dates: {
           lts: 'LTS',
+          calendar: {
+            lastDay: '[Yesterday at] LT',
+          },
         },
       },
     });
@@ -42,6 +45,16 @@ describe('I18n.js', () => {
 
       const result2 = I18n.l(1517774664107, { dateFormat: 'dates.lts' });
       expect(result2).toEqual('9:04:24 PM');
+    });
+
+    test('should use correct calendar', () => {
+      const date = new Date();
+      let yesterday = new Date(date.setDate(date.getDate() - 1));
+      yesterday = new Date(yesterday.setHours(15));
+      yesterday = new Date(yesterday.setMinutes(0));
+
+      const result3 = I18n.l(yesterday.toISOString(), { calendarFormat: 'dates.calendar' });
+      expect(result3).toEqual('Yesterday at 3:00 PM');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18nify",
-  "version": "1.11.14",
+  "version": "1.12.0",
   "description": "Simple i18n translation and localization components and helpers for React applications.",
   "main": "./build/index.js",
   "scripts": {
@@ -15,7 +15,8 @@
     "precommit": "npm run lint && npm test"
   },
   "jest": {
-    "verbose": true
+    "verbose": true,
+    "testURL": "http://localhost"
   },
   "files": [
     "build",

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -120,6 +120,18 @@ export default {
         Boolean(options.strictParse),
       ).format(this.t(options.dateFormat));
     }
+    if (options.calendarFormat) {
+      let calendarFormat = this.t(options.calendarFormat);
+      if (typeof calendarFormat !== 'object') {
+        calendarFormat = {};
+      }
+      return moment(
+        value,
+        options.parseFormat,
+        this._locale,
+        Boolean(options.strictParse),
+      ).calendar(null, calendarFormat);
+    }
     if (typeof value === 'number') {
       if (global.Intl) {
         if (!(Intl.NumberFormat &&

--- a/src/lib/Localize.jsx
+++ b/src/lib/Localize.jsx
@@ -15,6 +15,7 @@ export default class Localize extends BaseComponent {
       PropTypes.object]).isRequired,
     options: PropTypes.object,
     dateFormat: PropTypes.string,
+    calendarFormat: PropTypes.string,
     dangerousHTML: PropTypes.bool,
     className: PropTypes.string,
     style: PropTypes.objectOf(PropTypes.oneOfType([
@@ -29,9 +30,9 @@ export default class Localize extends BaseComponent {
 
   render() {
     const {
-      tag: Tag, value, dateFormat, options = {}, dangerousHTML, style, className,
+      tag: Tag, value, dateFormat, calendarFormat, options = {}, dangerousHTML, style, className,
     } = this.props;
-    const localization = I18n._localize(value, { ...options, dateFormat });
+    const localization = I18n._localize(value, { ...options, dateFormat, calendarFormat });
 
     if (dangerousHTML) {
       return (


### PR DESCRIPTION
This is very handy for outputing dates relatively using the same library that localization already imports.
Here's the link to what it uses: http://momentjs.com/docs/#/displaying/calendar-time/ (included it in the readme).
Also added test coverage for the calendar.