### PR TITLE
Only include enUS locale be default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,27 @@ import { I18n, t } from 'react-i18nify';
 <I18n render={() => <input placeholder={t("application.title")} />} />
 ```
 
+## Locales
+
+react-i18nify uses [date-fns](https://github.com/date-fns/date-fns) internally to handle localization. In order to reduce the base bundle size, react-i18nify only includes the `en-US` locale by default. If you need additional locales, you can add them manually using `addLocale` or `addLocales`. For a list of available locales, refer to the [date-fns list](https://github.com/date-fns/date-fns/tree/master/src/locale).
+
+```javascript
+import { addLocale, addLocales, setLocale } from 'react-i18nify';
+import nl from 'date-fns/locale/nl';
+import it from 'date-fns/locale/it';
+
+// Add a single locale
+addLocale('nl', nl);
+setLocale('nl');
+
+// Add multiple locales
+addLocales({
+  nl: nl,
+  it: it,
+});
+setLocale('it');
+```
+
 ## API Reference
 
 ### `<Translate>`
@@ -161,6 +182,34 @@ React I18n wrapper component, with the following prop:
 * `render` (func)
 
 The return value of the provide function will be rendered and automatically re-render when the locale or translations change.
+
+### `addLocale(name, locale)`
+
+Add a [date-fns locale](https://github.com/date-fns/date-fns/tree/master/src/locale) to the available locales.
+
+```javascript
+import { addLocale, setLocale } from 'react-i18nify';
+import nl from 'date-fns/locale/nl';
+
+addLocale('nl', nl);
+setLocale('nl');
+```
+
+### `addLocales(localesObject)`
+
+Add multiple [date-fns locales](https://github.com/date-fns/date-fns/tree/master/src/locale) to the available locales at once.
+
+```javascript
+import { addLocales, setLocale } from 'react-i18nify';
+import nl from 'date-fns/locale/nl';
+import it from 'date-fns/locale/it';
+
+addLocales({
+  nl: nl,
+  it: it,
+});
+setLocale('it');
+```
 
 ### `setLocale(locale, rerenderComponents = true)`
 

--- a/__test__/index.spec.js
+++ b/__test__/index.spec.js
@@ -1,21 +1,45 @@
 /* global describe, test, expect */
 
-import { setLocale, setTranslations, Translate, Localize, I18n } from '../src';
+import {
+  addLocale,
+  addLocales,
+  getLocale,
+  setLocale,
+  setLocaleGetter,
+  getTranslations,
+  setTranslations,
+  setTranslationsGetter,
+  setHandleMissingTranslation,
+  t,
+  l,
+  forceComponentsUpdate,
+  Translate,
+  Localize,
+  I18n,
+} from '../src';
 
 describe('index.js', () => {
-  test('should export setLocale function', () => {
-    expect(setLocale).toBeDefined();
-  });
-  test('should export setTranslations function', () => {
-    expect(setTranslations).toBeDefined();
-  });
-  test('should export <Translate/> component', () => {
-    expect(Translate).toBeDefined();
-  });
-  test('should export <Localize/> component', () => {
-    expect(Localize).toBeDefined();
-  });
-  test('should export <I18n/> component', () => {
-    expect(I18n).toBeDefined();
+  const exportedFunctions = [
+    addLocale,
+    addLocales,
+    getLocale,
+    setLocale,
+    setLocaleGetter,
+    getTranslations,
+    setTranslations,
+    setTranslationsGetter,
+    setHandleMissingTranslation,
+    t,
+    l,
+    forceComponentsUpdate,
+    Translate,
+    Localize,
+    I18n,
+  ];
+
+  exportedFunctions.forEach(exportedFunction => {
+    test(`should export ${exportedFunction.name} function`, () => {
+      expect(exportedFunction).toBeDefined();
+    });
   });
 });

--- a/__test__/lib/API.spec.js
+++ b/__test__/lib/API.spec.js
@@ -1,6 +1,9 @@
-/* global describe, test, expect, beforeEach, */
+/* global describe, test, expect, beforeEach, beforeAll */
 
+import nl from 'date-fns/locale/nl';
+import zh from 'date-fns/locale/zh-CN';
 import {
+  addLocales,
   getLocale,
   getTranslations,
   setLocale,
@@ -13,6 +16,10 @@ import {
 } from '../../src';
 
 describe('API', () => {
+  beforeAll(() => {
+    addLocales({ nl, zh });
+  });
+
   describe('setLocale', () => {
     setLocale('zh');
     const result = getLocale();

--- a/__test__/lib/Localize.spec.js
+++ b/__test__/lib/Localize.spec.js
@@ -25,6 +25,7 @@ describe('Localize.jsx', () => {
     test('should handle date localization', () => {
       const component = mount(<Localize
         value="2016-07-04"
+        parseFormat="yyyy-MM-dd"
         dateFormat="date"
       />);
       expect(component.type()).toBe(Localize);
@@ -35,6 +36,7 @@ describe('Localize.jsx', () => {
       setLocale('nl');
       const component = mount(<Localize
         value="2016-07-04"
+        parseFormat="yyyy-MM-dd"
         dateFormat="date"
       />);
       expect(component.type()).toBe(Localize);
@@ -44,6 +46,7 @@ describe('Localize.jsx', () => {
     test('should handle locale switching', () => {
       const component = mount(<Localize
         value="2016-07-04"
+        parseFormat="yyyy-MM-dd"
         dateFormat="date"
       />);
       expect(component.text()).toBe('July 4th, 2016');

--- a/__test__/lib/Localize.spec.js
+++ b/__test__/lib/Localize.spec.js
@@ -1,9 +1,15 @@
 /* global describe, test, expect, beforeAll, beforeEach */
 
 import React from 'react';
+import nl from 'date-fns/locale/nl';
 import { mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { setLocale, setTranslations, Localize } from '../../src';
+import {
+  addLocales,
+  setLocale,
+  setTranslations,
+  Localize,
+} from '../../src';
 
 describe('Localize.jsx', () => {
   beforeAll(() => {
@@ -16,6 +22,7 @@ describe('Localize.jsx', () => {
         date: 'd MMMM yyyy',
       },
     });
+    addLocales({ nl });
   });
 
   describe('<Localize/> component', () => {

--- a/__test__/lib/locale.spec.js
+++ b/__test__/lib/locale.spec.js
@@ -1,0 +1,35 @@
+/* global describe, test, expect, beforeEach */
+
+import nlLocale from 'date-fns/locale/nl';
+import itLocale from 'date-fns/locale/it';
+import { addLocale, addLocales, setLocale } from '../../src';
+import { settings } from '../../src/lib/core';
+
+describe('addLocale', () => {
+  beforeEach(() => {
+    settings.availableLocales = {};
+    addLocale('nl', nlLocale);
+  });
+
+  test('adds the nl locale', () => {
+    setLocale('nl');
+    expect(settings.localeObject).toEqual(nlLocale);
+  });
+});
+
+describe('addLocales', () => {
+  beforeEach(() => {
+    settings.availableLocales = {};
+    addLocales({ nl: nlLocale, it: itLocale });
+  });
+
+  test('can set the nl locale', () => {
+    setLocale('nl');
+    expect(settings.localeObject).toEqual(nlLocale);
+  });
+
+  test('can set the it locale', () => {
+    setLocale('it');
+    expect(settings.localeObject).toEqual(itLocale);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,17 @@
 export { default as Translate } from './lib/Translate';
 export { default as Localize } from './lib/Localize';
 export { default as I18n } from './lib/I18n';
-export * from './lib/core';
+export {
+  addLocale,
+  addLocales,
+  getLocale,
+  setLocale,
+  setLocaleGetter,
+  getTranslations,
+  setTranslations,
+  setTranslationsGetter,
+  setHandleMissingTranslation,
+  t,
+  l,
+  forceComponentsUpdate,
+} from './lib/core';

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -4,13 +4,14 @@
 import IntlPolyfill from 'intl';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
-import * as locales from 'date-fns/locale';
+import enUS from 'date-fns/locale/en-US';
 import BaseComponent from './Base';
 import { fetchTranslation, replace } from './utils';
 
-const settings = {
+export const settings = {
+  availableLocales: { 'en-US': enUS },
   localeKey: 'en',
-  localeObject: locales.enUS,
+  localeObject: enUS,
   translationsObject: {},
   getTranslations: null,
   getLocale: null,
@@ -30,7 +31,7 @@ const settings = {
 
   set locale(locale) {
     this.localeKey = locale;
-    this.localeObject = locales[locale] || locales[locale.split('-')[0]] || locales.enUS;
+    this.localeObject = this.availableLocales[locale] || this.availableLocales[locale.split('-')[0]] || enUS;
   },
 };
 
@@ -42,6 +43,17 @@ export const setLocale = (locale, rerenderComponents = true) => {
   if (rerenderComponents) {
     BaseComponent.rerenderAll();
   }
+};
+
+export const addLocale = (name, locale) => {
+  settings.availableLocales[name] = locale;
+};
+
+export const addLocales = (locales) => {
+  settings.availableLocales = {
+    ...settings.availableLocales,
+    ...locales,
+  };
 };
 
 export const getTranslations = () => settings.translations;


### PR DESCRIPTION
@gerbenmeyer Let me know what you think.

Resolves: https://github.com/sealninja/react-i18nify/issues/58

~~Still TODO:~~
- ~~Add docs~~
- ~~Add unit tests for `addLocale` and `addLocales`~~

In order to reduce bundle size, only include the enUS locale by default. In order to facilitate using other locales, this introduces `addLocale` and `addLocales` function, which can be used to configure the available locales.

Some notes:
- I had to fix the `Localize` tests. The `new Date('2016-07-04')` fallback parses in utc, which could then format to '2016-07-03' if your local timezone has a negative UTC offset. Passing a `dateFormat` solves this issue, but this behavior might be a bug in the first place
- [date-fns docs](https://date-fns.org/v2.7.0/docs/I18n) tell you to use named imports like `import { enUS } from 'date-fns/locale'`, but this won't reduce the bundle size for webpack and probably other bundlers (lodash gets around a similar issue with a babel plugin https://github.com/lodash/babel-plugin-lodash). We should use `import enUS from 'date-fns/locale/en-US'`, which will only add the en-US locale to the bundle as expected