### PR TITLE
Actually publish the TypeScript types for consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "Simple i18n translation and localization components and helpers for React applications.",
   "main": "./build/index.js",
-  "types": "types",
+  "types": "./types/index.d.ts",
   "scripts": {
     "test": "jest --verbose",
     "test:watch": "npm test -- --watch",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "files": [
     "build",
     "src",
-    "example"
+    "example",
+    "types"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build",
     "src",
     "example",
-    "types"
+    "types/index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, the supplied TypeScript types are not getting published in the NPM, so they cannot be used.