### PR TITLE
Added wrapper replacement support for the translate function

### DIFF
--- a/__test__/API.spec.js
+++ b/__test__/API.spec.js
@@ -68,13 +68,14 @@ describe('API', () => {
           application: {
             empty: '',
             hello: 'Hello, %{name}!',
+            hello_with_link: 'Hello %{link}%{name}%{/link}!',
           },
         },
         nl: {
           application: {
             empty: '',
             hello: 'Hallo, %{name}!',
-            hello_with_link: 'Hello %{link}%{name}%{/link}!',
+            hello_with_link: 'Hallo %{link}%{name}%{/link}!',
           },
         },
       });
@@ -98,10 +99,10 @@ describe('API', () => {
 
       test('should handle nested dynamic placeholder', () => {
         const result1 = translateFunction('application', { name: 'Aad' });
-        expect(result1).toEqual({ empty: '', hello: 'Hello, Aad!' });
+        expect(result1).toEqual({ empty: '', hello: 'Hello, Aad!', hello_with_link: 'Hello %{link}Aad%{/link}!' });
 
         const result2 = translateFunction('application', { name: 'Piet' });
-        expect(result2).toEqual({ empty: '', hello: 'Hello, Piet!' });
+        expect(result2).toEqual({ empty: '', hello: 'Hello, Piet!', hello_with_link: 'Hello %{link}Piet%{/link}!' });
       });
 
       test('should handle empty translation', () => {
@@ -115,12 +116,12 @@ describe('API', () => {
       });
 
       test('should support wrapper functions with nested replacements', () => {
-        const result = translateFunction('Hello %{link}%{name}%{/link}!', {
-          link: (children) => <a href="/profile">{children}</a>,
+        const result = translateFunction('application.hello_with_link', {
+          link: (children) => `<a href="/profile">${children}</a>`,
           name: 'Aad',
         });
 
-        expect(renderToString(<>{result}</>)).toContain('Hello <a href="/profile">Aad</a>!');
+        expect(result).toEqual('Hello <a href="/profile">Aad</a>!');
       });
     });
   });

--- a/__test__/API.spec.js
+++ b/__test__/API.spec.js
@@ -74,6 +74,7 @@ describe('API', () => {
           application: {
             empty: '',
             hello: 'Hallo, %{name}!',
+            hello_with_link: 'Hello %{link}%{name}%{/link}!',
           },
         },
       });
@@ -111,6 +112,15 @@ describe('API', () => {
       test('should support providing locale', () => {
         const result1 = translateFunction('application.hello', { name: 'Aad' }, { locale: 'nl' });
         expect(result1).toEqual('Hallo, Aad!');
+      });
+
+      test('should support wrapper functions with nested replacements', () => {
+        const result = translateFunction('Hello %{link}%{name}%{/link}!', {
+          link: (children) => <a href="/profile">{children}</a>,
+          name: 'Aad',
+        });
+
+        expect(renderToString(<>{result}</>)).toContain('Hello <a href="/profile">Aad</a>!');
       });
     });
   });

--- a/__test__/Translate.spec.js
+++ b/__test__/Translate.spec.js
@@ -11,6 +11,7 @@ describe('Translate.jsx', () => {
       en: {
         application: {
           hello: 'Hello, %{name}!',
+          hello_link: 'Hello, %{link}%{name}%{/link}!',
           title: 'Awesome app with i18n!',
         },
         export: 'Export %{count} items',
@@ -55,6 +56,12 @@ describe('Translate.jsx', () => {
     test('should handle dynamic placeholder', () => {
       const component = <Translate name="Aad" value="application.hello" />;
       expect(renderToString(component)).toMatch('Hello, Aad!');
+    });
+
+    test('should handle wrapper replacements with children functions', () => {
+      const component = <Translate link={(children) => <a href="/profile">{children}</a>} name="Aad" value="application.hello_link" />;
+
+      expect(renderToString(component)).toContain('Hello, <a href="/profile">Aad</a>!');
     });
 
     test('should handle pluralization', () => {

--- a/__test__/Translate.spec.js
+++ b/__test__/Translate.spec.js
@@ -11,7 +11,6 @@ describe('Translate.jsx', () => {
       en: {
         application: {
           hello: 'Hello, %{name}!',
-          hello_link: 'Hello, %{link}%{name}%{/link}!',
           title: 'Awesome app with i18n!',
         },
         export: 'Export %{count} items',
@@ -56,12 +55,6 @@ describe('Translate.jsx', () => {
     test('should handle dynamic placeholder', () => {
       const component = <Translate name="Aad" value="application.hello" />;
       expect(renderToString(component)).toMatch('Hello, Aad!');
-    });
-
-    test('should handle wrapper replacements with children functions', () => {
-      const component = <Translate link={(children) => <a href="/profile">{children}</a>} name="Aad" value="application.hello_link" />;
-
-      expect(renderToString(component)).toContain('Hello, <a href="/profile">Aad</a>!');
     });
 
     test('should handle pluralization', () => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,9 +1,34 @@
 import React from 'react';
 
+const WRAPPER_REPLACEMENT_REGEX = /%{([^/}]+)}(?=[\s\S]*%{\/\1})/g;
+
 export const replace = (translation, replacements) => {
   if (typeof translation === 'string') {
+    const wrapperReplacementKeys = new Set([...translation.matchAll(WRAPPER_REPLACEMENT_REGEX)].map(([, key]) => key));
+
     let result = translation;
     Object.keys(replacements).forEach((replacement) => {
+      if (wrapperReplacementKeys.has(replacement)) {
+        if (typeof replacements[replacement] !== 'function') {
+          throw new Error(`The replacement value for "${replacement}" should be a function that receives children.`);
+        }
+
+        while (result.includes(`%{${replacement}}`)) {
+          const startIndex = result.indexOf(`%{${replacement}}`);
+          const endIndex = result.indexOf(`%{/${replacement}}`, startIndex);
+
+          if (startIndex === -1 || endIndex === -1) {
+            break;
+          }
+
+          const before = result.substring(0, startIndex);
+          const middle = result.substring(startIndex + replacement.length + 3, endIndex);
+          const after = result.substring(endIndex + replacement.length + 4);
+
+          result = `${before}${replacements[replacement](middle)}${after}`;
+        }
+      }
+
       result = result.split(`%{${replacement}}`).join(replacements[replacement] ?? '');
     });
     return result;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,7 +32,9 @@ export class Localize extends React.Component<LocalizeDateProps | LocalizeNumber
 export type Translations = Record<string, any>;
 // The `count` key has some special behavior, so we need to support number. See src/lib/utils.js#L36
 // The value gets piped into `Array.join`, so the number will get coerced to a string. Should be ok.
-export type Replacements = Record<string, string | number>;
+export type WrapperReplacement = (children: string | React.ReactElement) => string;
+export type ReplacementValue = string | number | React.ReactElement | WrapperReplacement;
+export type Replacements = Record<string, ReplacementValue>;
 
 export type TranslationsGetter = () => Translations;
 export function getTranslations(): Translations | undefined;

--- a/types/react-i18nify-tests.tsx
+++ b/types/react-i18nify-tests.tsx
@@ -83,4 +83,5 @@ t('foo.bar', { asdf: true }); // $ExpectError
 <Translate value="foo.bar" />;
 <Translate value="foo.bar" asdf="baz" />;
 <Translate value="foo.bar" count={1234} />;
+<Translate value="foo.bar" link={(children) => <a>{children}</a>} />;
 <Translate value="foo.bar" asdf={true} />; // $ExpectError


### PR DESCRIPTION
Adding this to prevent having html in the translations themselves and to not have to break the translations into different parts to be able to use the existing replacement logic.